### PR TITLE
Add OpenAI-powered image search app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_openai_api_key_here

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # filesearch
+
+Simple Flask app that searches a folder of images for content using OpenAI's vision capabilities.
+
+## Setup
+
+1. Create a virtual environment and install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Copy `.env.example` to `.env` and add your OpenAI API key:
+
+```bash
+cp .env.example .env
+```
+
+3. Place images to search inside `static/images/`.
+
+## Running
+
+```bash
+python main.py
+```
+
+Then open your browser at `http://localhost:5000` and enter a search description.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,64 @@
+import os
+import base64
+from flask import Flask, render_template, request, redirect, url_for
+from openai import OpenAI
+from dotenv import load_dotenv
+
+load_dotenv()
+
+app = Flask(__name__)
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+IMAGE_DIR = os.path.join('static', 'images')
+
+
+def analyze_image(image_path: str, query: str) -> bool:
+    """Ask OpenAI if the image contains the query text."""
+    with open(image_path, 'rb') as img_file:
+        b64 = base64.b64encode(img_file.read()).decode('utf-8')
+
+    prompt = f"Does this image contain {query}? Answer yes or no."
+    response = client.responses.create(
+        model="gpt-4o-mini",
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": prompt},
+                    {"type": "input_image", "image_base64": b64},
+                ],
+            }
+        ],
+    )
+
+    answer = response.output_text.strip().lower()
+    return answer.startswith("yes")
+
+
+@app.route('/', methods=['GET'])
+def index():
+    return render_template('index.html')
+
+
+@app.route('/search', methods=['POST'])
+def search():
+    query = request.form.get('query')
+    if not query:
+        return redirect(url_for('index'))
+
+    results = []
+    for filename in os.listdir(IMAGE_DIR):
+        path = os.path.join(IMAGE_DIR, filename)
+        if os.path.isfile(path):
+            try:
+                if analyze_image(path, query):
+                    results.append(os.path.join('images', filename))
+            except Exception:
+                # If OpenAI call fails, skip this image
+                continue
+
+    return render_template('index.html', results=results, query=query)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+openai
+python-dotenv

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Image Search</title>
+</head>
+<body>
+    <h1>Search Images</h1>
+    <form action="/search" method="post">
+        <input type="text" name="query" placeholder="Describe desired content" required>
+        <button type="submit">Search</button>
+    </form>
+
+    {% if results %}
+    <h2>Results for "{{ query }}"</h2>
+    {% for path in results %}
+        <div>
+            <img src="{{ url_for('static', filename=path) }}" alt="{{ path }}" style="max-width:300px;">
+        </div>
+    {% endfor %}
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask app to query a folder of images using OpenAI's vision API
- load API key from `.env` and search through images on demand
- add minimal frontend form and setup instructions

## Testing
- `python -m py_compile main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b22388c66c832097594c4ad50362bd